### PR TITLE
Fix D1 mini ESP32 pin mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Lunch Whistle
 
-This project implements an automated break timer using a WeMos D1 mini (ESP8266) and a relay to trigger a train whistle. A small web interface allows configuration of the whistle times.
+This project implements an automated break timer using a WeMos D1 mini ESP32 and a relay to trigger a train whistle. A small web interface allows configuration of the whistle times.
 
 ## Building
-Use the Arduino IDE or PlatformIO with the ESP8266 core. Copy `src/main.cpp` into your sketch and provide your WiFi credentials.
+Use the Arduino IDE or PlatformIO with the ESP32 core. Copy `src/main.cpp` into your sketch and provide your WiFi credentials. Connect the relay to GPIO5 (labeled `D1` on the board).
 
 ## Usage
 1. Flash the code to the WeMos D1 mini.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,12 @@
 #include <Arduino.h>
-#include <ESP8266WiFi.h>
-#include <ESP8266WebServer.h>
+#include <WiFi.h>
+#include <WebServer.h>
 #include <time.h>
 
 const char* ssid = "your_ssid";     // replace with your WiFi SSID
 const char* password = "your_password"; // replace with your WiFi password
 
-const int relayPin = D1; // Relay control pin
+const int relayPin = 5; // GPIO5 (D1 label) for the relay
 const int MAX_TIMES = 8; // Max number of whistle times
 
 struct WhistleTime {
@@ -20,7 +20,7 @@ int blast1Duration = 500; // first blast length (ms)
 int blast2Duration = 1500; // second blast length (ms)
 const int blastPause = 200; // pause between blasts (ms)
 
-ESP8266WebServer server(80);
+WebServer server(80);
 
 void handleRoot();
 void handleConfig();


### PR DESCRIPTION
## Summary
- document the relay GPIO for the D1 mini ESP32
- use numeric GPIO pin instead of the ESP8266-specific `D1` macro

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847166c692c8324bd62e4fe4b15ff4b